### PR TITLE
Rework recipe to support cmake

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-11
+    vmImage: macOS-12
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -19,6 +23,8 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,10 +2,6 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -23,8 +19,6 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,13 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:
 - '16'
-c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -96,31 +96,6 @@ MIPS/IRIX C compiler. In 1994 (I think the correct year) SGI agreed (at my reque
 open-source libdwarf (and in 1999 to open-source dwarfdump) so anyone could use them.
 
 
-About libdwarf-testing-meta
----------------------------
-
-Home: https://www.prevanders.net/dwarf.html
-
-Package license: LGPL-2.1-only AND GPL-2.0-only
-
-Summary: library and utility for DWARF (meta with everything enable post-install check)
-
-Development: https://github.com/davea42/libdwarf-code
-
-Documentation: https://www.prevanders.net/libdwarfdoc/
-
-The DWARF Debugging Information Format is of interest to programmers working on compilers and
-debuggers (and anyone interested in reading or writing DWARF information). It was developed by a
-committee (known as the PLSIG at the time) starting around 1991. Starting around 1991 SGI got
-involved with the committee and then developed the libdwarf and dwarfdump tools for SGI-internal
-use and as part of SGI IRIX developer tools. From around 1993 dwarfdump and libdwarf were
-shipped (as an executable and archive respectively, not source) with every release of the SGI
-MIPS/IRIX C compiler. In 1994 (I think the correct year) SGI agreed (at my request) to
-open-source libdwarf (and in 1999 to open-source dwarfdump) so anyone could use them.
-
-This package can run 'make check' using installed library and dwarfdump via `conda build --test libdwarf-meta-testing`
-
-
 Current build status
 ====================
 
@@ -168,7 +143,6 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dwarfdump-green.svg)](https://anaconda.org/conda-forge/dwarfdump) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dwarfdump.svg)](https://anaconda.org/conda-forge/dwarfdump) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dwarfdump.svg)](https://anaconda.org/conda-forge/dwarfdump) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dwarfdump.svg)](https://anaconda.org/conda-forge/dwarfdump) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libdwarf-green.svg)](https://anaconda.org/conda-forge/libdwarf) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libdwarf.svg)](https://anaconda.org/conda-forge/libdwarf) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libdwarf.svg)](https://anaconda.org/conda-forge/libdwarf) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libdwarf.svg)](https://anaconda.org/conda-forge/libdwarf) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libdwarf--dev-green.svg)](https://anaconda.org/conda-forge/libdwarf-dev) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libdwarf-dev.svg)](https://anaconda.org/conda-forge/libdwarf-dev) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libdwarf-dev.svg)](https://anaconda.org/conda-forge/libdwarf-dev) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libdwarf-dev.svg)](https://anaconda.org/conda-forge/libdwarf-dev) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libdwarf--testing--meta-green.svg)](https://anaconda.org/conda-forge/libdwarf-testing-meta) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libdwarf-testing-meta.svg)](https://anaconda.org/conda-forge/libdwarf-testing-meta) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libdwarf-testing-meta.svg)](https://anaconda.org/conda-forge/libdwarf-testing-meta) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libdwarf-testing-meta.svg)](https://anaconda.org/conda-forge/libdwarf-testing-meta) |
 
 Installing libdwarf
 ===================
@@ -180,16 +154,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `dwarfdump, libdwarf, libdwarf-dev, libdwarf-testing-meta` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `dwarfdump, libdwarf, libdwarf-dev` can be installed with `conda`:
 
 ```
-conda install dwarfdump libdwarf libdwarf-dev libdwarf-testing-meta
+conda install dwarfdump libdwarf libdwarf-dev
 ```
 
 or with `mamba`:
 
 ```
-mamba install dwarfdump libdwarf libdwarf-dev libdwarf-testing-meta
+mamba install dwarfdump libdwarf libdwarf-dev
 ```
 
 It is possible to list all of the versions of `dwarfdump` available on your platform with `conda`:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,39 +1,4 @@
 #!/bin/bash
 
-set -xe 
-export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig:$BUILD_PREFIX/lib/pkgconfig
-
-# we patch the autotools files to add extra options for testing
-# go ahead and regen
-autoreconf --install --force
-
-mkdir build
-cd build
-
-#cmake -DCMAKE_BUILD_TYPE=Release \
-#      -DCMAKE_INSTALL_MANDIR=man \
-#      -DBUILD_NON_SHARED=FALSE \
-#      -DBUILD_SHARED=TRUE \
-#      -DDO_TESTING=TRUE \
-#      $CMAKE_ARGS ..
-#cmake  --build . -j${CPU_COUNT}
-#ctest -R self
-# README.cmake says install isn't working correctly yet
-# doesn't include pkgconfig file and installs into weird places
-
-../configure --enable-shared \
-          --disable-static \
-	  --prefix=$PREFIX \
-	  --mandir=$PREFIX/man
-
-make -j${CPU_COUNT}
-make check
-make install
-mv $PREFIX/include/libdwarf-*/libdwarf.h $PREFIX/include
-# leave dwarf.h inside include/libdwarf-0 because elfutils also has a vendored dwarf.h
-# but we want libdwarf.h to not be versioned
-
-cd ..
-# cleanup src directory because tests will copy it in for running on
-# installed artifacts
-rm -rf build
+cmake ${CMAKE_ARGS} -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED=YES -DBUILD_NON_SHARED=NO
+cmake --build build --config Release --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/davea42/libdwarf-code/releases/download/v{{ version }}/libdwarf-{{ version }}.tar.xz
-  sha256: 22b66d06831a76f6a062126cdcad3fcc58540b89a1acb23c99f8861f50999ec3
+  sha256: c1cd51467f9cb8459cd27d4071857abc56191cc5d4182d8bdd7744030f88f830
   patches:
     - patches/0001-add-enable_libdwarf-and-enable_dwarfdump-to-configur.patch
     - patches/0002-use-PATH-resolution-when-testing-dwarfdump.patch
@@ -19,11 +19,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake       # [win]
-    - autoconf    # [unix]
-    - automake    # [unix]
-    - libtool     # [unix]
-    - make        # [unix]
+    - cmake
+    - ninja       # [unix]
     - pkg-config  # [unix]
     - git  # for better patch application
     - python >=3  # for test scripts
@@ -45,6 +42,8 @@ outputs:
         - {{ pin_subpackage('libdwarf') }}
     files:
       - bin/dwarfdump
+      - lib/libdwarf.so          # [linux]
+      - lib/libdwarf.dylib       # [osx]
       - share/dwarfdump/dwarfdump.conf
       - man/man1/dwarfdump.1
     test:
@@ -94,8 +93,9 @@ outputs:
         - {{ pin_subpackage('libdwarf', exact=True) }}
     files:
       - include/libdwarf.h
-      - include/libdwarf-?/dwarf.h
+      - include/dwarf.h
       - lib/pkgconfig/libdwarf*
+      - lib/cmake/libdwarf
       - lib/libdwarf.so          # [linux]
       - lib/libdwarf.dylib       # [osx]
     test:
@@ -103,12 +103,22 @@ outputs:
         - zlib
         - zstd
         - pkg-config
+        - cmake
+        - ninja
+        - {{ compiler('c') }}
+      files:
+        - test
       commands:
         - pkg-config --print-provides libdwarf
-        - pkg-config --print-errors --exact-version=$PKG_VERSION libdwarf
+        - pkg-config --print-errors --exact-version="\"$PKG_VERSION\"" libdwarf
         - test -f $PREFIX/include/libdwarf.h
-        - test -f $PREFIX/include/libdwarf-?/dwarf.h
+        - test -f $PREFIX/include/dwarf.h
         - test -f $PREFIX/lib/libdwarf${SHLIB_EXT}
+        - test -f $PREFIX/lib/cmake/libdwarf/libdwarfConfig.cmake
+        - cd test
+        - cmake . -GNinja -DCMAKE_BUILD_TYPE=Release
+        - cmake --build . --config Release
+        - ./program
 
     about:
       home: https://www.prevanders.net/dwarf.html
@@ -169,65 +179,6 @@ outputs:
         - src/lib/libdwarf/LIBDWARFCOPYRIGHT
         - src/lib/libdwarf/LGPL.txt
         - src/lib/libdwarf/COPYING
-      doc_url: https://www.prevanders.net/libdwarfdoc/
-      dev_url: https://github.com/davea42/libdwarf-code
-
-  - name: libdwarf-testing-meta
-    requirements:
-      host:
-        - zlib
-        - zstd
-      run:
-        - {{ pin_subpackage('dwarfdump', exact=True) }}
-        - {{ pin_subpackage('libdwarf-dev', exact=True) }}
-    test:
-      requires:
-        - {{ compiler('c') }}
-        - make         # [unix]
-        - pkg-config   # [unix]
-        - autoconf     # [unix]
-        - automake     # [unix]
-        - libtool      # [unix]
-        - python >=3
-        - zlib
-        - zstd
-      source_files:
-        - '*'  # yes, we configure to not build and rerun make check with installed artifacts
-      commands:
-        - dwarfdump --version
-        - pkg-config --print-provides libdwarf
-        - pkg-config --print-errors --exact-version=$PKG_VERSION libdwarf
-        - mkdir build && cd build
-          # add -ldwarf to LDLIBS so that linker looks for it in -L$PREFIX/lib provided by our compiler
-          # activation scripts
-        - LDLIBS+=-ldwarf ../configure --disable-libdwarf --disable-dwarfdump
-        - make -C test check || ( cat test/test-suite.log; exit 1 )
-    about:
-      home: https://www.prevanders.net/dwarf.html
-      summary: library and utility for DWARF (meta with everything enable post-install check)
-      description: |
-        The DWARF Debugging Information Format is of interest to programmers working on compilers and
-        debuggers (and anyone interested in reading or writing DWARF information). It was developed by a
-        committee (known as the PLSIG at the time) starting around 1991. Starting around 1991 SGI got
-        involved with the committee and then developed the libdwarf and dwarfdump tools for SGI-internal
-        use and as part of SGI IRIX developer tools. From around 1993 dwarfdump and libdwarf were
-        shipped (as an executable and archive respectively, not source) with every release of the SGI
-        MIPS/IRIX C compiler. In 1994 (I think the correct year) SGI agreed (at my request) to
-        open-source libdwarf (and in 1999 to open-source dwarfdump) so anyone could use them.
-
-        This package can run 'make check' using installed library and dwarfdump via `conda build --test libdwarf-meta-testing`
-      #  libdwarf is LGPL-2.1 and dwarfdump is GPL-2.0
-      #  There are some files under less-restrictive licenses but there you have it
-      license: LGPL-2.1-only AND GPL-2.0-only
-      license_family: GPL
-      license_file:
-        - COPYING
-        - src/lib/libdwarf/LIBDWARFCOPYRIGHT
-        - src/lib/libdwarf/LGPL.txt
-        - src/lib/libdwarf/COPYING
-        - src/bin/dwarfdump/COPYING
-        - src/bin/dwarfdump/DWARFDUMPCOPYRIGHT
-        - src/bin/dwarfdump/GPL.txt
       doc_url: https://www.prevanders.net/libdwarfdoc/
       dev_url: https://github.com/davea42/libdwarf-code
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - cmake
     - ninja       # [unix]
     - pkg-config  # [unix]
@@ -34,6 +35,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib("c") }}
       host:
         - zlib
         - zstd
@@ -86,6 +88,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib("c") }}
       host:
         - zlib
         - zstd
@@ -106,6 +109,7 @@ outputs:
         - cmake
         - ninja
         - {{ compiler('c') }}
+        - {{ stdlib("c") }}
       files:
         - test
       commands:
@@ -147,6 +151,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib("c") }}
       host:
         - zlib
         - libzlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0002-use-PATH-resolution-when-testing-dwarfdump.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_package LANGUAGES C)
+
+find_package(libdwarf REQUIRED)
+
+add_executable(program test.c)
+target_link_libraries(program PRIVATE libdwarf::dwarf)

--- a/recipe/test/test.c
+++ b/recipe/test/test.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "dwarf.h"
+#include "libdwarf.h"
+
+void example1(Dwarf_Die somedie) {
+    Dwarf_Debug dbg = 0;
+    Dwarf_Signed atcount;
+    Dwarf_Attribute *atlist;
+    Dwarf_Error error = 0;
+    Dwarf_Signed i = 0;
+    int errv;
+    errv = dwarf_attrlist(somedie, &atlist, &atcount, &error);
+    if (errv == DW_DLV_OK) {
+        for (i = 0; i < atcount; ++i) {
+            Dwarf_Bool is_string;
+            dwarf_hasform(atlist[i], DW_FORM_string, &is_string, &error);
+            dwarf_dealloc(dbg, atlist[i], DW_DLA_ATTR);
+        }
+        dwarf_dealloc(dbg, atlist, DW_DLA_LIST);
+    }
+    else if(errv == DW_DLV_ERROR){
+        dwarf_dealloc(dbg, error, DW_DLA_ERROR);
+    }
+}
+int main(void){
+    Dwarf_Die somedie;
+    memset(&somedie, 0, sizeof(somedie));
+    example1(somedie);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR updates the recipe to use the cmake build process which allows the library to be better used by cmake while also supporting the pkgconfig usage.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closes #15